### PR TITLE
Resuming a session on a Windows machine

### DIFF
--- a/Segmentation.praat
+++ b/Segmentation.praat
@@ -468,7 +468,6 @@ while (startup_node$ != startup_node_quit$) and (startup_node$ != startup_node_s
           # audio-anonymization log with the interval [0, 0.01] muted.
           Create Table with column names... 'audioLog_table$' 1 'al_xmin$' 'al_xmax$'
           Select Table 'audioLog_table$'
-          Append row
           Set numeric value... 1 'al_xmin$' 0
           Set numeric value... 1 'al_xmax$' 0.01
           # [SEGMENTATION TEXTGRID]


### PR DESCRIPTION
The previous version of the script had a bug that caused it to crash when loading the wave file during a resumed session on a Windows machine.  The script has been edited and sent to Jamie to be tested on a Windows machine.  I will wait to confirm the pull request and merge the changes until I've heard back from Jamie that this edit successfully fixes the bug.
