### PR TITLE
Creating & loading the audio-anonymization log

### DIFF
--- a/Segmentation.praat
+++ b/Segmentation.praat
@@ -467,7 +467,7 @@ while (startup_node$ != startup_node_quit$) and (startup_node$ != startup_node_s
           # an interval that needs to be anonymized.  Initialize the
           # audio-anonymization log with the interval [0, 0.01] muted.
           Create Table with column names... 'audioLog_table$' 1 'al_xmin$' 'al_xmax$'
-          Select Table 'audioLog_table$'
+          select Table 'audioLog_table$'
           Set numeric value... 1 'al_xmin$' 0
           Set numeric value... 1 'al_xmax$' 0.01
           # [SEGMENTATION TEXTGRID]


### PR DESCRIPTION
This pull request fixes a bug that causes an error when an audio-anonymization log is created during the start-up procedure of the first segmentation session for a given file.
